### PR TITLE
Updated AL-Go System Files

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -18,10 +18,10 @@ $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumen
 $webClient.Encoding = [System.Text.Encoding]::UTF8
 Write-Host "Downloading GitHub Helper module"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v3.0/Github-Helper.psm1', $GitHubHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp5MXRuF-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
 Write-Host "Downloading AL-Go Helper script"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
-$webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v3.0/AL-Go-Helper.ps1', $ALGoHelperPath)
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp5MXRuF-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/.AL-Go/localdevenv.ps1
+++ b/.AL-Go/localdevenv.ps1
@@ -1,3 +1,144 @@
+#
+# Script for creating local development environment
+# Please do not modify this script as it will be auto-updated from the AL-Go Template
+# Recommended approach is to use as is or add a script (freddyk-devenv.ps1), which calls this script with the user specific parameters
+#
+Param(
+    [string] $containerName = "",
+    [string] $auth = "",
+    [pscredential] $credential = $null,
+    [string] $licenseFileUrl = "",
+    [string] $insiderSasToken = "",
+    [switch] $fromVSCode
+)
 
+$ErrorActionPreference = "stop"
+Set-StrictMode -Version 2.0
 
-# Dummy comment
+try {
+$webClient = New-Object System.Net.WebClient
+$webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
+$webClient.Encoding = [System.Text.Encoding]::UTF8
+Write-Host "Downloading GitHub Helper module"
+$GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp5MXRuF-Actions/main/Github-Helper.psm1', $GitHubHelperPath)
+Write-Host "Downloading AL-Go Helper script"
+$ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
+$webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp5MXRuF-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+
+Import-Module $GitHubHelperPath
+. $ALGoHelperPath -local
+
+$baseFolder = GetBaseFolder -folder $PSScriptRoot
+$project = GetProject -baseFolder $baseFolder -projectALGoFolder $PSScriptRoot
+
+Clear-Host
+Write-Host
+Write-Host -ForegroundColor Yellow @'
+  _                     _   _____             ______            
+ | |                   | | |  __ \           |  ____|           
+ | |     ___   ___ __ _| | | |  | | _____   __ |__   _ ____   __
+ | |    / _ \ / __/ _` | | | |  | |/ _ \ \ / /  __| | '_ \ \ / /
+ | |____ (_) | (__ (_| | | | |__| |  __/\ V /| |____| | | \ V / 
+ |______\___/ \___\__,_|_| |_____/ \___| \_/ |______|_| |_|\_/  
+                                                                
+'@
+
+Write-Host @'
+This script will create a docker based local development environment for your project.
+
+NOTE: You need to have Docker installed, configured and be able to create Business Central containers for this to work.
+If this fails, you can setup a cloud based development environment by running cloudDevEnv.ps1
+
+All apps and test apps will be compiled and published to the environment in the development scope.
+The script will also modify launch.json to have a Local Sandbox configuration point to your environment.
+
+'@
+
+$settings = ReadSettings -baseFolder $baseFolder -project $project -userName $env:USERNAME
+
+Write-Host "Checking System Requirements"
+$dockerProcess = (Get-Process "dockerd" -ErrorAction Ignore)
+if (!($dockerProcess)) {
+    Write-Host -ForegroundColor Red "Dockerd process not found. Docker might not be started, not installed or not running Windows Containers."
+}
+if ($settings.keyVaultName) {
+    if (-not (Get-Module -ListAvailable -Name 'Az.KeyVault')) {
+        Write-Host -ForegroundColor Red "A keyvault name is defined in Settings, you need to have the Az.KeyVault PowerShell module installed (use Install-Module az) or you can set the keyVaultName to an empty string in the user settings file ($($ENV:UserName).settings.json)."
+    }
+}
+
+Write-Host
+
+if (-not $containerName) {
+    $containerName = Enter-Value `
+        -title "Container name" `
+        -question "Please enter the name of the container to create" `
+        -default "bcserver" `
+        -trimCharacters @('"',"'",' ')
+}
+
+if (-not $auth) {
+    $auth = Select-Value `
+        -title "Authentication mechanism for container" `
+        -options @{ "Windows" = "Windows Authentication"; "UserPassword" = "Username/Password authentication" } `
+        -question "Select authentication mechanism for container" `
+        -default "UserPassword"
+}
+
+if (-not $credential) {
+    if ($auth -eq "Windows") {
+        $credential = Get-Credential -Message "Please enter your Windows Credentials" -UserName $env:USERNAME
+        $CurrentDomain = "LDAP://" + ([ADSI]"").distinguishedName
+        $domain = New-Object System.DirectoryServices.DirectoryEntry($CurrentDomain,$credential.UserName,$credential.GetNetworkCredential().password)
+        if ($null -eq $domain.name) {
+            Write-Host -ForegroundColor Red "Unable to verify your Windows Credentials, you might not be able to authenticate to your container"
+        }
+    }
+    else {
+        $credential = Get-Credential -Message "Please enter username and password for your container" -UserName "admin"
+    }
+}
+
+if (-not $licenseFileUrl) {
+    if ($settings.type -eq "AppSource App") {
+        $description = "When developing AppSource Apps, your local development environment needs the developer licensefile with permissions to your AppSource app object IDs"
+        $default = ""
+    }
+    else {
+        $description = "When developing PTEs, you can optionally specify a developer licensefile with permissions to object IDs of your dependant apps"
+        $default = "none"
+    }
+
+    $licenseFileUrl = Enter-Value `
+        -title "LicenseFileUrl" `
+        -description $description `
+        -question "Local path or a secure download URL to license file " `
+        -default $default `
+        -doNotConvertToLower `
+        -trimCharacters @('"',"'",' ')
+}
+
+if ($licenseFileUrl -eq "none") {
+    $licenseFileUrl = ""
+}
+
+CreateDevEnv `
+    -kind local `
+    -caller local `
+    -containerName $containerName `
+    -baseFolder $baseFolder `
+    -project $project `
+    -auth $auth `
+    -credential $credential `
+    -licenseFileUrl $licenseFileUrl `
+    -insiderSasToken $insiderSasToken
+}
+catch {
+    Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"
+}
+finally {
+    if ($fromVSCode) {
+        Read-Host "Press ENTER to close this window"
+    }
+}

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -1,5 +1,5 @@
 {
   "type": "AppSource App",
-  "templateUrl": "https://github.com/microsoft/AL-Go-AppSource@v3.0",
+  "templateUrl": "https://github.com/businesscentralapps/tmp5MXRuF-AppSource@main",
   "MicrosoftTelemetryConnectionString": ""
 }

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,11 +1,73 @@
+## Preview
+
+Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.
+
+### Issues
+
+Issue 542 Deploy Workflow fails
+
+### New Settings
+- `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module
+
+## v3.1
+
+### Issues
+
+Issue #446 Wrong NewLine character in Release Notes
+Issue #453 DeliverToStorage - override fails reading secrets
+Issue #434 Use gh auth token to get authentication token instead of gh auth status
+Issue #501 The Create New App action will now use 22.0.0.0 as default application reference and include NoImplicitwith feature.
+
+
+### New behavior
+
+The following workflows:
+
+- Create New App
+- Create New Test App
+- Create New Performance Test App
+- Increment Version Number
+- Add Existing App
+- Create Online Development Environment
+
+All these actions now uses the selected branch in the **Run workflow** dialog as the target for the Pull Request or Direct COMMIT.
+
+### New Settings
+
+- `UseCompilerFolder`: Setting useCompilerFolder to true causes your pipelines to use containerless compiling. Unless you also set `doNotPublishApps` to true, setting useCompilerFolder to true won't give you any performance advantage, since AL-Go for GitHub will still need to create a container in order to publish and test the apps. In the future, publishing and testing will be split from building and there will be other options for getting an instance of Business Central for publishing and testing. 
+- `vsixFile`: vsixFile should be a direct download URL to the version of the AL Language extension you want to use for building the project or repo. By default, AL-Go will use the AL Language extension that comes with the Business Central Artifacts.
+
+### New Workflows
+
+- **_BuildALGoProject** is a reusable workflow that unites the steps for building an AL-Go projects. It has been reused in the following workflows: _CI/CD_, _Pull Request Build_, _NextMinor_, _NextMajor_ and _Current_.
+The workflow appears under the _Actions_ tab in GitHub, but it is not actionable in any way.  
+
+### New Actions
+
+- **DetermineArtifactUrl** is used to determine which artifacts to use for building a project in CI/CD, PullRequestHandler, Current, NextMinor and NextMajor workflows.
+
+### License File
+
+With the changes to the CRONUS license in Business Central version 22, that license can in most cases be used as a developer license for AppSource Apps and it is no longer mandatory to specify a license file in AppSource App repositories.
+Obviously, if you build and test your app for Business Central versions prior to 21, it will fail if you don't specify a licenseFileUrl secret.
+
 ## v3.0
 
 ### **NOTE:** When upgrading to this version
 When upgrading to this version form earlier versions of AL-Go for GitHub, you will need to run the _Update AL-Go System Files_ workflow twice if you have the `useProjectDependencies` setting set to _true_.
 
+### Publish to unknown environment
+You can now run the **Publish To Environment** workflow without creating the environment in GitHub or settings up-front, just by specifying the name of a single environment in the Environment Name when running the workflow.
+Subsequently, if an AuthContext secret hasn't been created for this environment, the Device Code flow authentication will be initiated from the Publish To Environment workflow and you can publish to the new environment without ever creating a secret.
+Open Workflow details to get the device Code for authentication in the job summary for the initialize job.
+
+### Create Online Dev. Environment
+When running the **Create Online Dev. Environment** workflow without having the _adminCenterApiCredentials_ secret created, the workflow will intiate the deviceCode flow and allow you to authenticate to the Business Central Admin Center.
+Open Workflow details to get the device Code for authentication in the job summary for the initialize job.
+
 ### Issues
 - Issue #391 Create release action - CreateReleaseBranch error
-- Issue #434 Building local DevEnv, downloading dependencies: Authentication fails when using "gh auth status"
+- Issue 434 Building local DevEnv, downloading dependencies: Authentication fails when using "gh auth status"
 
 ### Changes to Pull Request Process
 In v2.4 and earlier, the PullRequestHandler would trigger the CI/CD workflow to run the PR build.

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Add existing app or test app'
 
+run-name: "Add existing app or test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:
@@ -36,13 +38,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0090"
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/AddExistingApp@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0090"

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -38,6 +38,7 @@ jobs:
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -46,22 +47,27 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: '*'
+
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,7 +86,7 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "Secrets=$($deliveryTargetSecrets -join ',')"
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -155,14 +161,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CheckForUpdates@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
@@ -171,165 +177,25 @@ jobs:
   Build:
     needs: [ Initialization ]
     if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
-    defaults:
-      run:
-        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
     name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
-    outputs:
-      AppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.AppsArtifactsName }}
-      TestAppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestAppsArtifactsName }}
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-    
-      - name: Download thisbuild artifacts
-        if: env.workflowDepth > 1
-        uses: actions/download-artifact@v3
-        with:
-          path: '.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,storageContext,gitHubPackagesContext'
-
-      - name: Run pipeline
-        id: RunPipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.0
-        env:
-          BuildMode: ${{ matrix.buildMode }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-          projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          secretsJson: ${{ env.RepoSecrets }}
-          buildMode: ${{ matrix.buildMode }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.0
-        if: success() || failure()
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          settingsJson: ${{ env.Settings }}
-          project: ${{ matrix.project }}
-          buildMode: ${{ matrix.buildMode }}
-          branchName: ${{ github.ref_name }}
-
-      - name: Upload thisbuild artifacts - apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Upload thisbuild artifacts - test apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Publish artifacts - apps
-        uses: actions/upload-artifact@v3
-        if: github.ref_name == 'main' || startswith(github.ref_name, 'release/') || needs.Initialization.outputs.deliveryTargetCount > 0 || needs.Initialization.outputs.environmentCount > 0
-        with:
-          name: ${{ env.AppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - dependencies
-        uses: actions/upload-artifact@v3
-        if: github.ref_name == 'main' || startswith(github.ref_name, 'release/') || needs.Initialization.outputs.deliveryTargetCount > 0 || needs.Initialization.outputs.environmentCount > 0
-        with:
-          name: ${{ env.DependenciesArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Dependencies/'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test apps
-        uses: actions/upload-artifact@v3
-        if: github.ref_name == 'main' || startswith(github.ref_name, 'release/') || needs.Initialization.outputs.deliveryTargetCount > 0 || needs.Initialization.outputs.environmentCount > 0
-        with:
-          name: ${{ env.TestAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.BuildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@v3
-        if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',matrix.project)) != '')
-        with:
-          name: ${{ env.ContainerEventLogArtifactsName }}
-          path: '${{ matrix.project }}/ContainerEventLog.evtx'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.TestResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.BcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,storageContext,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || needs.Initialization.outputs.deliveryTargetCount > 0 || needs.Initialization.outputs.environmentCount > 0 }}
+      signArtifacts: true
+      useArtifactCache: true
 
   Deploy:
     needs: [ Initialization, Build ]
@@ -357,12 +223,12 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -445,7 +311,7 @@ jobs:
           Write-Host "projects=$projects"
 
       - name: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/Deploy@main
         env:
           AuthContext: ${{ steps.authContext.outputs.authContext }}
         with:
@@ -474,12 +340,12 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -498,7 +364,7 @@ jobs:
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/Deliver@main
         env:
           deliveryContext: ${{ steps.deliveryContext.outputs.deliveryContext }}
         with:
@@ -518,7 +384,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0091"

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new app'
 
+run-name: "Create a new app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:
@@ -46,20 +48,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0092"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: type
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CreateApp@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -73,7 +75,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0092"

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -1,5 +1,7 @@
 name: ' Create Online Dev. Environment'
 
+run-name: "Create Online Dev. Environment for [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:
@@ -28,27 +30,30 @@ env:
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
 jobs:
-  CreateOnlineDevelopmentEnvironment:
+  Initialize:
     runs-on: [ windows-latest ]
+    outputs:
+      deviceCode: ${{ steps.authenticate.outputs.deviceCode }}
+      telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0093"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -58,41 +63,75 @@ jobs:
           secrets: 'adminCenterApiCredentials'
 
       - name: Check AdminCenterApiCredentials / Initiate Device Login (open to see code)
+        id: authenticate
         run: |
           $ErrorActionPreference = "STOP"
           Set-StrictMode -version 2.0
           $adminCenterApiCredentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:adminCenterApiCredentials))
           if ($adminCenterApiCredentials) {
-            Write-Host "AdminCenterApiCredentials provided!"
+            Write-Host "AdminCenterApiCredentials provided in secret $($ENV:adminCenterApiCredentialsSecretName)!"
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "Admin Center Api Credentials was provided in a secret called $($ENV:adminCenterApiCredentialsSecretName). Using this information for authentication."
           }
           else {
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v3.0/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp5MXRuF-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
-            MaskValueInLog -value $authContext.deviceCode
-            $adminCenterApiCredentials = "{""deviceCode"":""$($authContext.deviceCode)""}"
-            Add-Content -Path $env:GITHUB_ENV -Value "adminCenterApiCredentials=$([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($adminCenterApiCredentials)))"
             CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Admin Center Api and could not locate a secret called $($ENV:adminCenterApiCredentialsSecretName) (https://aka.ms/ALGoSettings#AdminCenterApiCredentialsSecretName)`n`n$($authContext.message)"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+          }
+
+  CreateDevelopmentEnvironment:
+    runs-on: [ windows-latest ]
+    name: Create Development Environment
+    needs: [ Initialize ]
+    env:
+      deviceCode: ${{ needs.Initialize.outputs.deviceCode }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Read settings
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+
+      - name: Read secrets
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: 'adminCenterApiCredentials'
+
+      - name: Set AdminCenterApiCredentials
+        run: |
+          if ($env:deviceCode) {
+            $adminCenterApiCredentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
+            Add-Content -path $env:GITHUB_ENV -value "adminCenterApiCredentials=$adminCenterApiCredentials"
           }
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CreateDevelopmentEnvironment@main
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          parentTelemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}
           environmentName: ${{ github.event.inputs.environmentName }}
           reUseExistingEnvironment: ${{ github.event.inputs.reUseExistingEnvironment }}
           directCommit: ${{ github.event.inputs.directCommit }}
-          adminCenterApiCredentials: ${{ env.adminCenterApiCredentials }} 
+          adminCenterApiCredentials: ${{ env.adminCenterApiCredentials }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0093"
-          telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          telemetryScopeJson: ${{ needs.Initialize.outputs.telemetryScopeJson }}

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new performance test app'
 
+run-name: "Create a new performance test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:
@@ -52,13 +54,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0102"
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CreateApp@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -73,7 +75,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0102"

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -66,14 +66,14 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0094"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -81,12 +81,12 @@ jobs:
 
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CheckForUpdates@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -110,7 +110,7 @@ jobs:
           }
           do {
             $repoArtifacts = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/actions/artifacts?per_page=100&page=$page" | ConvertFrom-Json
-            $allArtifacts += $repoArtifacts.Artifacts
+            $allArtifacts += $repoArtifacts.Artifacts | Where-Object { !$_.expired }
             $page++
           }
           while ($repoArtifacts.Artifacts.Count -gt 0)
@@ -171,7 +171,7 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CreateReleaseNotes@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -191,7 +191,7 @@ jobs:
               repo: context.repo.repo,
               tag_name: '${{ github.event.inputs.tag }}',
               name: '${{ github.event.inputs.name }}',
-              body: bodyMD.replaceAll('\\n','\n'),
+              body: bodyMD.replaceAll('\\n','\n').replaceAll('%0A','\n').replaceAll('%0D','\n').replaceAll('%25','%'),
               draft: ${{ github.event.inputs.draft=='Y' }},
               prerelease: ${{ github.event.inputs.prerelease=='Y' }},
               make_latest: 'legacy',
@@ -213,13 +213,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -271,7 +271,7 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "nuGetContext=$nuGetContext"
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/Deliver@main
         if: ${{ steps.nuGetContext.outputs.nuGetContext }}
         env:
           deliveryContext: ${{ steps.nuGetContext.outputs.nuGetContext }}
@@ -296,7 +296,7 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "storageContext=$storageContext"
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/Deliver@main
         if: ${{ steps.storageContext.outputs.storageContext }}
         env:
           deliveryContext: ${{ steps.storageContext.outputs.storageContext }}
@@ -334,7 +334,7 @@ jobs:
     needs: [ CreateRelease, UploadArtifacts ]
     steps:
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.CreateRelease.outputs.telemetryScopeJson }}
@@ -351,7 +351,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0094"

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -1,5 +1,7 @@
 name: 'Create a new test app'
 
+run-name: "Create a new test app in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:
@@ -48,13 +50,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0095"
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CreateApp@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -68,7 +70,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0095"

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -26,6 +26,7 @@ jobs:
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,21 +35,26 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0101"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          
+
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
+      
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -56,139 +62,23 @@ jobs:
   Build:
     needs: [ Initialization ]
     if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
-    defaults:
-      run:
-        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
     name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
-    outputs:
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-    
-      - name: Download thisbuild artifacts
-        if: env.workflowDepth > 1
-        uses: actions/download-artifact@v3
-        with:
-          path: '${{ github.workspace }}\.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
-
-      - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.0
-        env:
-          BuildMode: ${{ matrix.buildMode }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-          projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          secretsJson: ${{ env.RepoSecrets }}
-          buildMode: ${{ matrix.buildMode }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.0
-        if: success() || failure()
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          settingsJson: ${{ env.Settings }}
-          project: ${{ matrix.project }}
-          buildMode: ${{ matrix.buildMode }}
-          branchName: ${{ github.ref_name }}
-          suffix: 'Current'
-
-      - name: Upload thisbuild artifacts - apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Upload thisbuild artifacts - test apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.buildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@v3
-        if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',matrix.project)) != '')
-        with:
-          name: ${{ env.ContainerEventLogArtifactsName }}
-          path: '${{ matrix.project }}/ContainerEventLog.evtx'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.TestResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.BcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsNameSuffix: 'Current'
 
   PostProcess:
     if: always()
@@ -200,7 +90,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0101"

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -1,5 +1,7 @@
 name: ' Increment Version Number'
 
+run-name: "Increment Version Number in [${{ github.ref_name }}]"
+
 on:
   workflow_dispatch:
     inputs:
@@ -36,13 +38,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0096"
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/IncrementVersionNumber@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -52,7 +54,7 @@ jobs:
   
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0096"

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -26,6 +26,7 @@ jobs:
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,21 +35,26 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0099"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -56,139 +62,23 @@ jobs:
   Build:
     needs: [ Initialization ]
     if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
-    defaults:
-      run:
-        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
     name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
-    outputs:
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-    
-      - name: Download thisbuild artifacts
-        if: env.workflowDepth > 1
-        uses: actions/download-artifact@v3
-        with:
-          path: '${{ github.workspace }}\.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
-
-      - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.0
-        env:
-          BuildMode: ${{ matrix.buildMode }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-          projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          secretsJson: ${{ env.RepoSecrets }}
-          buildMode: ${{ matrix.buildMode }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.0
-        if: success() || failure()
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          settingsJson: ${{ env.Settings }}
-          project: ${{ matrix.project }}
-          buildMode: ${{ matrix.buildMode }}
-          branchName: ${{ github.ref_name }}
-          suffix: 'NextMajor'
-
-      - name: Upload thisbuild artifacts - apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Upload thisbuild artifacts - test apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.buildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@v3
-        if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',matrix.project)) != '')
-        with:
-          name: ${{ env.ContainerEventLogArtifactsName }}
-          path: '${{ matrix.project }}/ContainerEventLog.evtx'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.TestResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.BcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsNameSuffix: 'NextMajor'
 
   PostProcess:
     if: always()
@@ -200,7 +90,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0099"

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -26,6 +26,7 @@ jobs:
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,21 +35,26 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0100"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -56,139 +62,23 @@ jobs:
   Build:
     needs: [ Initialization ]
     if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
-    defaults:
-      run:
-        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
     name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
-    outputs:
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-    
-      - name: Download thisbuild artifacts
-        if: env.workflowDepth > 1
-        uses: actions/download-artifact@v3
-        with:
-          path: '${{ github.workspace }}\.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
-
-      - name: Run pipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.0
-        env:
-          BuildMode: ${{ matrix.buildMode }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-          projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          secretsJson: ${{ env.RepoSecrets }}
-          buildMode: ${{ matrix.buildMode }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.0
-        if: success() || failure()
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          settingsJson: ${{ env.Settings }}
-          project: ${{ matrix.project }}
-          buildMode: ${{ matrix.buildMode }}
-          branchName: ${{ github.ref_name }}
-          suffix: 'NextMinor'
-
-      - name: Upload thisbuild artifacts - apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Upload thisbuild artifacts - test apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-          retention-days: 1
-      
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.buildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@v3
-        if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',matrix.project)) != '')
-        with:
-          name: ${{ env.ContainerEventLogArtifactsName }}
-          path: '${{ matrix.project }}/ContainerEventLog.evtx'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.TestResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.BcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,codeSignCertificateUrl,codeSignCertificatePassword,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsNameSuffix: 'NextMinor'
 
   PostProcess:
     if: always()
@@ -200,7 +90,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0100"

--- a/.github/workflows/PublishToAppSource.yaml
+++ b/.github/workflows/PublishToAppSource.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0103"
@@ -53,13 +53,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -78,7 +78,7 @@ jobs:
           Write-Host "deliveryContext=$deliveryContext"
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/Deliver@main
         env:
           deliveryContext: '${{ steps.deliveryContext.outputs.deliveryContext }}'
         with:
@@ -100,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0103"

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -31,34 +31,91 @@ jobs:
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
       environments: ${{ steps.ReadSettings.outputs.EnvironmentsJson }}
       environmentCount: ${{ steps.ReadSettings.outputs.EnvironmentCount }}
+      unknownEnvironment: ${{ steps.ReadSettings.outputs.UnknownEnvironment }}
+      deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0097"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: ${{ github.event.inputs.environmentName }}
           includeProduction: 'Y'
 
+      - name: EnvName
+        id: envName
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
+        run: |
+          $ErrorActionPreference = "STOP"
+          Set-StrictMode -version 2.0
+          $envName = '${{ fromJson(steps.ReadSettings.outputs.environmentsJson).matrix.include[0].environment }}'.split(' ')[0]
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
+
+      - name: Read secrets
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
+        env:
+          secrets: ${{ toJson(secrets) }}
+        with:
+          shell: powershell
+          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
+          settingsJson: ${{ env.Settings }}
+          secrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext'
+
+      - name: Authenticate
+        id: Authenticate
+        if: steps.ReadSettings.outputs.UnknownEnvironment == 1
+        run: |
+          $envName = '${{ steps.envName.outputs.envName }}'
+          $secretName = ''
+          $authContext = $null
+          "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
+            if (!($authContext)) {
+              $authContext = [System.Environment]::GetEnvironmentVariable($_)
+              if ($authContext) {
+                Write-Host "Using $_ secret as AuthContext"
+                $secretName = $_
+              }
+            }            
+          }
+          if ($authContext) {
+            Write-Host "AuthContext provided in secret $secretName!"
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AuthContext was provided in a secret called $secretName. Using this information for authentication."
+          }
+          else {
+            Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
+            $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
+            $webClient = New-Object System.Net.WebClient
+            $webClient.DownloadFile('https://raw.githubusercontent.com/businesscentralapps/tmp5MXRuF-Actions/main/AL-Go-Helper.ps1', $ALGoHelperPath)
+            . $ALGoHelperPath
+            $BcContainerHelperPath = DownloadAndImportBcContainerHelper -baseFolder $ENV:GITHUB_WORKSPACE
+            $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
+            CleanupAfterBcContainerHelper -bcContainerHelperPath $bcContainerHelperPath
+            Set-Content -Path $ENV:GITHUB_STEP_SUMMARY -value "AL-Go needs access to the Business Central Environment $('${{ steps.envName.outputs.envName }}'.Split(' ')[0]) and could not locate a secret called ${{ steps.envName.outputs.envName }}_AuthContext`n`n$($authContext.message)"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "deviceCode=$($authContext.deviceCode)"
+          }
+
   Deploy:
     needs: [ Initialization ]
-    if: ${{ needs.Initialization.outputs.environmentCount > 0 }}
+    if: needs.Initialization.outputs.environmentCount > 0
     strategy: ${{ fromJson(needs.Initialization.outputs.environments) }}
     runs-on: ${{ fromJson(matrix.os) }}
     name: Deploy to ${{ matrix.environment }}
     environment:
       name: ${{ matrix.environment }}
+    env:
+      deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,12 +129,12 @@ jobs:
           Add-Content -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -99,6 +156,9 @@ jobs:
             $deployToSetting = [PSCustomObject]@{}
           }
           $authContext = $null
+          if ($env:deviceCode) {
+            $authContext = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("{""deviceCode"":""$($env:deviceCode)""}"))
+          }
           "$($envName)-AuthContext", "$($envName)_AuthContext", "AuthContext" | ForEach-Object {
             if (!($authContext)) {
               $authContext = [System.Environment]::GetEnvironmentVariable($_)
@@ -150,7 +210,6 @@ jobs:
             $projects = ($projects.Split(',') | Where-Object { $buildProjects -contains $_ }) -join ','
           }
           Add-Content -Path $env:GITHUB_OUTPUT -Value "authContext=$authContext"
-          Write-Host "authContext=$authContext"
           Add-Content -Path $env:GITHUB_OUTPUT -Value "environmentName=$environmentName"
           Write-Host "environmentName=$([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($environmentName)))"
           Write-Host "environmentName (as Base64)=$environmentName"
@@ -158,7 +217,7 @@ jobs:
           Write-Host "projects=$projects"
 
       - name: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/Deploy@main
         env:
           AuthContext: ${{ steps.authContext.outputs.authContext }}
         with:
@@ -179,7 +238,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0097"

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -34,7 +34,7 @@ jobs:
           lfs: true
           ref: refs/pull/${{ github.event.number }}/merge
 
-      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v3.0
+      - uses: businesscentralapps/tmp5MXRuF-Actions/VerifyPRChanges@main
         with:
           baseSHA: ${{ github.event.pull_request.base.sha }}
           headSHA: ${{ github.event.pull_request.head.sha }}
@@ -52,6 +52,7 @@ jobs:
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,22 +62,27 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0104"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           getEnvironments: '*'
+      
+      - name: Determine Workflow Depth
+        id: DetermineWorkflowDepth
+        run: |
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "WorkflowDepth=$($env:workflowDepth)"
           
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/DetermineProjectsToBuild@main
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -84,142 +90,23 @@ jobs:
   Build:
     needs: [ Initialization ]
     if: (!failure()) && (!cancelled()) && fromJson(needs.Initialization.outputs.buildOrderJson)[0].projectsCount > 0
-    runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
-    defaults:
-      run:
-        shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.Initialization.outputs.buildOrderJson)[0].buildDimensions }}
       fail-fast: false
     name: Build ${{ matrix.project }} - ${{ matrix.buildMode }}
-    outputs:
-      AppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.AppsArtifactsName }}
-      TestAppsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestAppsArtifactsName }}
-      TestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.TestResultsArtifactsName }}
-      BcptTestResultsArtifactsName: ${{ steps.calculateArtifactNames.outputs.BcptTestResultsArtifactsName }}
-      BuildOutputArtifactsName: ${{ steps.calculateArtifactNames.outputs.BuildOutputArtifactsName }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          ref: refs/pull/${{ github.event.number }}/merge
-    
-      - name: Download thisbuild artifacts
-        if: env.workflowDepth > 1
-        uses: actions/download-artifact@v3
-        with:
-          path: '.dependencies'
-
-      - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-
-      - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
-        env:
-          secrets: ${{ toJson(secrets) }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          settingsJson: ${{ env.Settings }}
-          secrets: 'licenseFileUrl,insiderSasToken,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
-
-      - name: Run pipeline
-        id: RunPipeline
-        uses: microsoft/AL-Go-Actions/RunPipeline@v3.0
-        env:
-          BuildMode: ${{ matrix.buildMode }}
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          project: ${{ matrix.project }}
-          projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
-          settingsJson: ${{ env.Settings }}
-          secretsJson: ${{ env.RepoSecrets }}
-          buildMode: ${{ matrix.buildMode }}
-
-      - name: Calculate Artifact names
-        id: calculateArtifactsNames
-        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v3.0
-        if: success() || failure()
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          settingsJson: ${{ env.Settings }}
-          project: ${{ matrix.project }}
-          buildMode: ${{ matrix.buildMode }}
-          branchName: ${{ github.ref_name }}
-
-      - name: Upload thisbuild artifacts - apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/Apps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Upload thisbuild artifacts - test apps
-        if: env.workflowDepth > 1
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-          path: '${{ matrix.project }}/.buildartifacts/TestApps/'
-          if-no-files-found: ignore
-          retention-days: 1
-
-      - name: Publish artifacts - build output
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',matrix.project)) != '')
-        with:
-          name: ${{ env.BuildOutputArtifactsName }}
-          path: '${{ matrix.project }}/BuildOutput.txt'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - container event log
-        uses: actions/upload-artifact@v3
-        if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',matrix.project)) != '')
-        with:
-          name: ${{ env.ContainerEventLogArtifactsName }}
-          path: '${{ matrix.project }}/ContainerEventLog.evtx'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',matrix.project)) != '')
-        with:
-          name: ${{ env.TestResultsArtifactsName }}
-          path: '${{ matrix.project }}/TestResults.xml'
-          if-no-files-found: ignore
-
-      - name: Publish artifacts - bcpt test results
-        uses: actions/upload-artifact@v3
-        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',matrix.project)) != '')
-        with:
-          name: ${{ env.BcptTestResultsArtifactsName }}
-          path: '${{ matrix.project }}/bcptTestResults.json'
-          if-no-files-found: ignore
-
-      - name: Analyze Test Results
-        id: analyzeTestResults
-        if: success() || failure()
-        uses: microsoft/AL-Go-Actions/AnalyzeTests@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
-
-      - name: Cleanup
-        if: always()
-        uses: microsoft/AL-Go-Actions/PipelineCleanup@v3.0
-        with:
-          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
-          Project: ${{ matrix.project }}
+    uses: ./.github/workflows/_BuildALGoProject.yaml
+    secrets: inherit
+    with:
+      shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+      runsOn: ${{ needs.Initialization.outputs.githubRunner }}
+      checkoutRef: refs/pull/${{ github.event.number }}/merge
+      parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      project: ${{ matrix.project }}
+      buildMode: ${{ matrix.buildMode }}
+      projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      secrets: 'licenseFileUrl,insiderSasToken,keyVaultCertificateUrl,keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext'
+      publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
 
   PostProcess:
     runs-on: [ windows-latest ]
@@ -234,7 +121,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0104"

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       templateUrl:
-        description: Template Repository URL (current is https://github.com/microsoft/AL-Go-AppSource@v3.0)
+        description: Template Repository URL (current is https://github.com/businesscentralapps/tmp5MXRuF-AppSource@main)
         required: false
         default: ''
       directCommit:
@@ -32,20 +32,20 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowInitialize@main
         with:
           shell: powershell
           eventId: "DO0098"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           get: keyVaultName,ghTokenWorkflowSecretName,templateUrl
 
       - name: Read secrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
         env:
           secrets: ${{ toJson(secrets) }}
         with:
@@ -82,7 +82,7 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/CheckForUpdates@main
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v3.0
+        uses: businesscentralapps/tmp5MXRuF-Actions/WorkflowPostProcess@main
         with:
           shell: powershell
           eventId: "DO0098"

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -1,0 +1,245 @@
+name: '_Build AL-GO project'
+
+run-name: 'Build project ${{ inputs.project }}'
+
+on:
+  workflow_call:
+    inputs:
+      shell:
+        description: Shell in which you want to run the action (powershell or pwsh)
+        required: false
+        default: powershell
+        type: string
+      runsOn: 
+        description: JSON-formatted string og the types of machine to run the build job on
+        required: true
+        type: string
+      checkoutRef:
+        description: Ref to checkout
+        required: false
+        default: ${{ github.ref }}
+        type: string
+      project:
+        description: Name of the built project
+        required: true
+        type: string
+      projectDependenciesJson:
+        description: Dependencies of the built project in compressed Json format
+        required: false
+        default: '{}'
+        type: string
+      buildMode:
+        description: Build mode used when building the artifacts
+        required: true
+        type: string
+      secrets:
+        description: A comma-separated string with the names of the secrets, required for the workflow.
+        required: false
+        default: ''
+        type: string
+      publishThisBuildArtifacts:
+        description: Flag indicating whether this build artifacts should be published
+        required: false
+        default: false
+        type: boolean
+      publishArtifacts:
+        description: Flag indicating whether the artifacts should be published
+        required: false
+        default: false
+        type: boolean
+      artifactsNameSuffix:
+        description: Suffix to add to the artifacts names
+        required: false
+        default: ''
+        type: string
+      signArtifacts:
+        description: Flag indicating whether the apps should be signed
+        required: false
+        default: false
+        type: boolean
+      useArtifactCache:
+        description: Flag determining whether to use the Artifacts Cache
+        required: false
+        default: false
+        type: boolean
+      parentTelemetryScopeJson:
+        description: Specifies the telemetry scope for the telemetry signal
+        required: false
+        type: string
+jobs:
+  BuildALGoProject:
+    runs-on: ${{ fromJson(inputs.runsOn) }}
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            ref: ${{ inputs.checkoutRef }}
+            lfs: true
+      
+        - name: Download thisbuild artifacts
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/download-artifact@v3
+          with:
+            path: '.dependencies'
+
+        - name: Read settings
+          uses: businesscentralapps/tmp5MXRuF-Actions/ReadSettings@main
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            project: ${{ inputs.project }}
+
+        - name: Read secrets
+          uses: businesscentralapps/tmp5MXRuF-Actions/ReadSecrets@main
+          env:
+            secrets: ${{ toJson(secrets) }}
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            settingsJson: ${{ env.Settings }}
+            secrets: ${{ inputs.secrets }}
+
+        - name: Determine ArtifactUrl
+          uses: businesscentralapps/tmp5MXRuF-Actions/DetermineArtifactUrl@main
+          id: determineArtifactUrl
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            project: ${{ inputs.project }}
+            settingsJson: ${{ env.Settings }}
+            secretsJson: ${{ env.RepoSecrets }}
+
+        - name: Cache Business Central Artifacts
+          if: env.useCompilerFolder == 'True' && inputs.useArtifactCache && steps.determineArtifactUrl.outputs.ArtifactCacheKey
+          uses: actions/cache@v3
+          with:
+            path: .artifactcache
+            key: ${{ steps.determineArtifactUrl.outputs.ArtifactCacheKey }}
+
+        - name: Run pipeline
+          id: RunPipeline
+          uses: businesscentralapps/tmp5MXRuF-Actions/RunPipeline@main
+          env:
+            BuildMode: ${{ inputs.buildMode }}
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            project: ${{ inputs.project }}
+            projectDependenciesJson: ${{ inputs.projectDependenciesJson }}
+            settingsJson: ${{ env.Settings }}
+            secretsJson: ${{ env.RepoSecrets }}
+            buildMode: ${{ inputs.buildMode }}
+
+        - name: Sign
+          if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
+          id: sign
+          uses: businesscentralapps/tmp5MXRuF-Actions/Sign@main
+          with:
+            shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+            azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
+            settingsJson: ${{ env.Settings }}
+            pathToFiles: '${{ matrix.project }}/.buildartifacts/Apps/*.app'
+            parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+
+        - name: Calculate Artifact names
+          id: calculateArtifactsNames
+          uses: businesscentralapps/tmp5MXRuF-Actions/CalculateArtifactNames@main
+          if: success() || failure()
+          with:
+            shell: ${{ inputs.shell }}
+            settingsJson: ${{ env.Settings }}
+            project: ${{ inputs.project }}
+            buildMode: ${{ inputs.buildMode }}
+            branchName: ${{ github.ref_name }}
+            suffix: ${{ inputs.artifactsNameSuffix }}
+
+        - name: Upload thisbuild artifacts - apps
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Apps/'
+            if-no-files-found: ignore
+            retention-days: 1
+
+        - name: Upload thisbuild artifacts - test apps
+          if: inputs.publishThisBuildArtifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+            if-no-files-found: ignore
+            retention-days: 1
+        
+        - name: Publish artifacts - apps
+          uses: actions/upload-artifact@v3
+          if: inputs.publishArtifacts
+          with:
+            name: ${{ env.AppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Apps/'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - dependencies
+          uses: actions/upload-artifact@v3
+          if: inputs.publishArtifacts
+          with:
+            name: ${{ env.DependenciesArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - test apps
+          uses: actions/upload-artifact@v3
+          if: inputs.publishArtifacts
+          with:
+            name: ${{ env.TestAppsArtifactsName }}
+            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - build output
+          uses: actions/upload-artifact@v3
+          if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
+          with:
+            name: ${{ env.BuildOutputArtifactsName }}
+            path: '${{ inputs.project }}/BuildOutput.txt'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - container event log
+          uses: actions/upload-artifact@v3
+          if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
+          with:
+            name: ${{ env.ContainerEventLogArtifactsName }}
+            path: '${{ inputs.project }}/ContainerEventLog.evtx'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - test results
+          uses: actions/upload-artifact@v3
+          if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',inputs.project)) != '')
+          with:
+            name: ${{ env.TestResultsArtifactsName }}
+            path: '${{ inputs.project }}/TestResults.xml'
+            if-no-files-found: ignore
+
+        - name: Publish artifacts - bcpt test results
+          uses: actions/upload-artifact@v3
+          if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',inputs.project)) != '')
+          with:
+            name: ${{ env.BcptTestResultsArtifactsName }}
+            path: '${{ inputs.project }}/bcptTestResults.json'
+            if-no-files-found: ignore
+
+        - name: Analyze Test Results
+          id: analyzeTestResults
+          if: success() || failure()
+          uses: businesscentralapps/tmp5MXRuF-Actions/AnalyzeTests@main
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            Project: ${{ inputs.project }}
+
+        - name: Cleanup
+          if: always()
+          uses: businesscentralapps/tmp5MXRuF-Actions/PipelineCleanup@main
+          with:
+            shell: ${{ inputs.shell }}
+            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+            Project: ${{ inputs.project }}


### PR DESCRIPTION
## Preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

### Issues

Issue 542 Deploy Workflow fails

### New Settings
- `keyVaultCodesignCertificateName`:  With this setting you can delegate the codesigning to an Azure Key Vault. This can be useful if your certificate has to be stored in a Hardware Security Module

## v3.1

### Issues

Issue #446 Wrong NewLine character in Release Notes
Issue #453 DeliverToStorage - override fails reading secrets
Issue #434 Use gh auth token to get authentication token instead of gh auth status
Issue #501 The Create New App action will now use 22.0.0.0 as default application reference and include NoImplicitwith feature.


### New behavior

The following workflows:

- Create New App
- Create New Test App
- Create New Performance Test App
- Increment Version Number
- Add Existing App
- Create Online Development Environment

All these actions now uses the selected branch in the **Run workflow** dialog as the target for the Pull Request or Direct COMMIT.

### New Settings

- `UseCompilerFolder`: Setting useCompilerFolder to true causes your pipelines to use containerless compiling. Unless you also set `doNotPublishApps` to true, setting useCompilerFolder to true won't give you any performance advantage, since AL-Go for GitHub will still need to create a container in order to publish and test the apps. In the future, publishing and testing will be split from building and there will be other options for getting an instance of Business Central for publishing and testing. 
- `vsixFile`: vsixFile should be a direct download URL to the version of the AL Language extension you want to use for building the project or repo. By default, AL-Go will use the AL Language extension that comes with the Business Central Artifacts.

### New Workflows

- **_BuildALGoProject** is a reusable workflow that unites the steps for building an AL-Go projects. It has been reused in the following workflows: _CI/CD_, _Pull Request Build_, _NextMinor_, _NextMajor_ and _Current_.
The workflow appears under the _Actions_ tab in GitHub, but it is not actionable in any way.  

### New Actions

- **DetermineArtifactUrl** is used to determine which artifacts to use for building a project in CI/CD, PullRequestHandler, Current, NextMinor and NextMajor workflows.

### License File

With the changes to the CRONUS license in Business Central version 22, that license can in most cases be used as a developer license for AppSource Apps and it is no longer mandatory to specify a license file in AppSource App repositories.
Obviously, if you build and test your app for Business Central versions prior to 21, it will fail if you don't specify a licenseFileUrl secret.

## v3.0

### **NOTE:** When upgrading to this version
When upgrading to this version form earlier versions of AL-Go for GitHub, you will need to run the _Update AL-Go System Files_ workflow twice if you have the `useProjectDependencies` setting set to _true_.

### Publish to unknown environment
You can now run the **Publish To Environment** workflow without creating the environment in GitHub or settings up-front, just by specifying the name of a single environment in the Environment Name when running the workflow.
Subsequently, if an AuthContext secret hasn't been created for this environment, the Device Code flow authentication will be initiated from the Publish To Environment workflow and you can publish to the new environment without ever creating a secret.
Open Workflow details to get the device Code for authentication in the job summary for the initialize job.

### Create Online Dev. Environment
When running the **Create Online Dev. Environment** workflow without having the _adminCenterApiCredentials_ secret created, the workflow will intiate the deviceCode flow and allow you to authenticate to the Business Central Admin Center.
Open Workflow details to get the device Code for authentication in the job summary for the initialize job.

### Issues
- Issue #391 Create release action - CreateReleaseBranch error
- Issue 434 Building local DevEnv, downloading dependencies: Authentication fails when using "gh auth status"

### Changes to Pull Request Process
In v2.4 and earlier, the PullRequestHandler would trigger the CI/CD workflow to run the PR build.
Now, the PullRequestHandler will perform the build and the CI/CD workflow is only run on push (or manual dispatch) and will perform a complete build.

### Build modes per project
Build modes can now be specified per project

### New Actions
- **DetermineProjectsToBuild** is used to determine which projects to build in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
- **CalculateArtifactNames** is used to calculate artifact names in PullRequestHandler, CI/CD, Current, NextMinor and NextMajor workflows.
- **VerifyPRChanges** is used to verify whether a PR contains changes, which are not allowed from a fork.
